### PR TITLE
Eliminate lint errors in Python2/3 flake8 (line length = 100)

### DIFF
--- a/object_manager.py
+++ b/object_manager.py
@@ -3,10 +3,10 @@
 # Eventually, the core solver should be moved to a new file.
 # Actually, the solver should be entirely rewritten.
 
-from collections import defaultdict
 from math import sqrt
 from numpy import array, dot, vdot, matrix
-from numpy.linalg import matrix_rank, solve, inv
+from numpy.linalg import inv
+
 
 class ObjectManager(object):
     def __init__(self):
@@ -77,7 +77,7 @@ class ObjectManager(object):
         for i in range(len(self._point_lru)):
             if self._point_lru[i] == p:
                 self._point_lru = ([p] + self._point_lru[0:i]
-                                      + self._point_lru[i+1:])
+                                   + self._point_lru[i+1:])
                 break
 
     def set_point_coords(self, point, x, y):
@@ -115,7 +115,6 @@ class ObjectManager(object):
         return new_matrix
 
     def can_add(self, ortho_m, idx):
-        r = ortho_m[0]
         new_row = sum(om[idx] * matrix(om) for om in ortho_m)
         for i, j in enumerate(new_row.tolist()[0]):
             if i == idx and round(j, 5) != 1:
@@ -196,4 +195,3 @@ class ObjectManager(object):
         sol = zip(sol[::2], sol[1::2])
         for point, mat_point in self._cached_point_to_matrix.iteritems():
             self._point_coords[point] = sol[mat_point]
-

--- a/primitives.py
+++ b/primitives.py
@@ -1,6 +1,7 @@
 import pygtk
 pygtk.require('2.0')
-import gtk, gobject, cairo
+import gtk
+
 
 class Primitive(object):
     def __init__(self, object_manager):
@@ -94,6 +95,7 @@ class Primitive(object):
         '''
         pass
 
+
 class Point(Primitive):
     '''
     This class wraps the ObjectManager's points.
@@ -139,8 +141,9 @@ class Point(Primitive):
         self._object_manager.set_point_coords(self.point(), x, y)
 
     def delete(self):
-        #TODO: remove our point from all structures.
+        # TODO: remove our point from all structures.
         pass
+
 
 class CenterPoint(Point):
     def __init__(self, object_manager, objects):
@@ -163,6 +166,7 @@ class CenterPoint(Point):
 
     def drag(self, offs_x, offs_y):
         pass
+
 
 class Pad(Primitive):
     def __init__(self, object_manager, x, y, w, h):
@@ -231,8 +235,7 @@ class Pad(Primitive):
         return (horiz_constraints +
                 vert_constraints +
                 eq_horiz_constraints +
-                eq_vert_constraints
-        )
+                eq_vert_constraints)
 
     def draw(self, cr):
         if self.selected():
@@ -255,6 +258,7 @@ class Pad(Primitive):
         for point in self.points:
             point.drag(offs_x, offs_y)
 
+
 class TwoPointConstraint(Primitive):
     '''
     Base class for any constraint between two points.
@@ -273,6 +277,7 @@ class TwoPointConstraint(Primitive):
     @classmethod
     def can_create(cls, objects):
         return len(objects) == 2 and all(isinstance(o, Point) for o in objects)
+
 
 class Horizontal(TwoPointConstraint):
     def constraints(self):
@@ -311,6 +316,7 @@ class Horizontal(TwoPointConstraint):
         cr.line_to(self.p2.x(), self.p2.y())
         cr.stroke()
 
+
 class Vertical(TwoPointConstraint):
     def constraints(self):
         return [
@@ -343,6 +349,7 @@ class Vertical(TwoPointConstraint):
         cr.line_to(self.p2.x(), self.p2.y())
         cr.stroke()
 
+
 class HorizDistance(TwoPointConstraint):
     def __init__(self, object_manager, objects):
         super(HorizDistance, self).__init__(object_manager, objects)
@@ -359,7 +366,7 @@ class HorizDistance(TwoPointConstraint):
         entry1.show()
         array.show()
         dialog.get_content_area().add(array)
-        #widget.connect("clicked", lambda x: win2.destroy())
+        # widget.connect("clicked", lambda x: win2.destroy())
         dialog.add_button("Ok", 1)
         dialog.add_button("Cancel", 2)
         result = dialog.run()
@@ -405,6 +412,7 @@ class HorizDistance(TwoPointConstraint):
     def drag(self, offs_x, offs_y):
         self.label_distance += offs_y
 
+
 class PadArray(Primitive):
     def __init__(self, object_manager, x, y):
         super(PadArray, self).__init__(object_manager)
@@ -425,7 +433,7 @@ class PadArray(Primitive):
         entry2.show()
         array.show()
         dialog.get_content_area().add(array)
-        #widget.connect("clicked", lambda x: win2.destroy())
+        # widget.connect("clicked", lambda x: win2.destroy())
         dialog.add_button("Ok", 1)
         dialog.add_button("Cancel", 2)
         result = dialog.run()
@@ -471,7 +479,7 @@ class PadArray(Primitive):
                     (
                         [(self.p(i, j).p(1, 1), 1, 0),
                          (self.p(i, j + 1).p(1, 1), -1, 0),
-                     ], 0),
+                         ], 0),
                 )
 
         for i in range(0, self.x - 1):
@@ -480,7 +488,7 @@ class PadArray(Primitive):
                     (
                         [(self.p(i, j).p(1, 1), 0, 1),
                          (self.p(i + 1, j).p(1, 1), 0, -1),
-                     ], 0),
+                         ], 0),
                 )
 
         # Same distance
@@ -491,7 +499,7 @@ class PadArray(Primitive):
                         [(self.p(i, j).p(1, 1), 0, 1),
                          (self.p(i, j + 1).p(1, 1), 0, -2),
                          (self.p(i, j + 2).p(1, 1), 0, 1),
-                     ], 0),
+                         ], 0),
                 )
 
         for i in range(0, self.x - 2):
@@ -501,7 +509,7 @@ class PadArray(Primitive):
                         [(self.p(i, j).p(1, 1), 1, 0),
                          (self.p(i + 1, j).p(1, 1), -2, 0),
                          (self.p(i + 2, j).p(1, 1), 1, 0),
-                     ], 0),
+                         ], 0),
                 )
 
         # Same size
@@ -515,7 +523,7 @@ class PadArray(Primitive):
                          (self.p(0, 0).p(0, 0), -1, 0),
                          (self.p(i, j).p(1, 0), -1, 0),
                          (self.p(i, j).p(0, 0), 1, 0),
-                     ], 0),
+                         ], 0),
                 )
                 all_constraints.append(
                     (
@@ -523,7 +531,7 @@ class PadArray(Primitive):
                          (self.p(0, 0).p(0, 0), 0, -1),
                          (self.p(i, j).p(0, 1), 0, -1),
                          (self.p(i, j).p(0, 0), 0, 1),
-                     ], 0),
+                         ], 0),
                 )
 
         return all_constraints

--- a/ui.py
+++ b/ui.py
@@ -1,11 +1,13 @@
+from __future__ import print_function
+
 import pygtk
 pygtk.require('2.0')
-import gtk, gobject, cairo
-from numpy.linalg import solve
+import gtk
 
 from object_manager import ObjectManager
-from primitives import (Pad, Horizontal, Vertical, Point, CenterPoint,
+from primitives import (Pad, Horizontal, Vertical, CenterPoint,
                         PadArray, HorizDistance, )
+
 
 class FPArea(gtk.DrawingArea):
     @classmethod
@@ -54,7 +56,7 @@ class FPArea(gtk.DrawingArea):
     def scroll_event(self, event):
         # When the scroll wheel is used, zoom in or out.
         x, y = self.coord_map(event.x, event.y)
-        print x, y
+        print(x, y)
         if event.direction == gtk.gdk.SCROLL_UP:
             self.scale_factor *= 1.3
         elif event.direction == gtk.gdk.SCROLL_DOWN:
@@ -62,7 +64,7 @@ class FPArea(gtk.DrawingArea):
         self.scale_x = event.x / self.scale_factor - x
         self.scale_y = event.y / self.scale_factor - y
 
-        print self.scale_factor, self.scale_x, self.scale_y
+        print(self.scale_factor, self.scale_x, self.scale_y)
         self.queue_draw()
 
     def recalculate(self):
@@ -96,7 +98,7 @@ class FPArea(gtk.DrawingArea):
                 break
         for p in to_remove:
             self.primitives.remove(p)
-            #TODO: these should be sets.
+            # TODO: these should be sets.
             if p in self.draw_primitives:
                 self.draw_primitives.remove(p)
 
@@ -111,7 +113,7 @@ class FPArea(gtk.DrawingArea):
             'd': HorizDistance,
         }
         keyname = gtk.gdk.keyval_name(event.keyval)
-        print keyname
+        print(keyname)
         if keyname == 'a':
             p = Pad(self.object_manager, self.x, self.y, 100, 50)
             self.object_manager.add_primitive(p)
@@ -121,7 +123,7 @@ class FPArea(gtk.DrawingArea):
             self.object_manager.add_primitive(p)
             self.recalculate()
         elif keyname == 'Delete':
-            print self.active_object
+            print(self.active_object)
             if self.active_object is not None:
                 self.delete(self.active_object)
             self.recalculate()
@@ -132,7 +134,7 @@ class FPArea(gtk.DrawingArea):
                 self.object_manager.add_primitive(p)
                 self.selected_primitives.clear()
             else:
-                print "Select two points."
+                print("Select two points.")
             self.recalculate()
         elif keyname == 'space':
             if self.active_object is not None:
@@ -152,7 +154,7 @@ class FPArea(gtk.DrawingArea):
                     self.object_manager.add_primitive(p)
                     self.deselect_all()
                 else:
-                    print "Cannot create constraint."
+                    print("Cannot create constraint.")
             self.recalculate()
         self.update_closest()
         self.queue_draw()
@@ -166,14 +168,14 @@ class FPArea(gtk.DrawingArea):
         return True
 
     def expose_event(self, event):
-        x , y, width, height = event.area
+        x, y, width, height = event.area
         self.window.draw_drawable(self.get_style().fg_gc[gtk.STATE_NORMAL],
                                   self.pixmap, x, y, x, y, width, height)
 
         cr = self.window.cairo_create()
-        #cr.rectangle(event.area.x, event.area.y,
-        #             event.area.width, event.area.height)
-        #cr.clip()
+        # cr.rectangle(event.area.x, event.area.y,
+        #              event.area.width, event.area.height)
+        # cr.clip()
         self.draw(cr)
         return False
 
@@ -189,7 +191,7 @@ class FPArea(gtk.DrawingArea):
         (p, dist) = self.object_manager.closest(self.x, self.y)
 
         if dist < 100:
-            if None is not self.active_object is not p:
+            if self.active_object is not None and p is not None:
                 self.active_object.deactivate()
             self.active_object = p
             if p is not None:
@@ -214,10 +216,10 @@ class FPArea(gtk.DrawingArea):
             self.update_closest()
         return
 
-        cr.restore()
-        cr.move_to(10,10)
-        cr.show_text("(%s, %s)" % (x, y))
-        cr.stroke()
+        # cr.restore()
+        # cr.move_to(10, 10)
+        # cr.show_text("(%s, %s)" % (x, y))
+        # cr.stroke()
 
     def draw_pixmap(self, width, height):
         rect = (int(self.x-5), int(self.y-5), 10, 10)
@@ -233,7 +235,7 @@ class FPArea(gtk.DrawingArea):
         else:
             x = event.x
             y = event.y
-            state = event.state
+            # state = event.state
 
         orig_x, orig_y = self.x, self.y
         self.x, self.y = self.coord_map(x, y)
@@ -249,12 +251,12 @@ class FPArea(gtk.DrawingArea):
     def click_event(self, event):
         x, y = self.coord_map(event.x, event.y)
 
-        print event.button
+        print(event.button)
 
-        print "Click %s %s" % (x, y)
+        print("Click %s %s" % (x, y))
         if event.button == 1:
             if self.active_object is not None:
-                print "Start drag"
+                print("Start drag")
                 self.dragging_object = self.active_object
                 self.dragging_object.drag(0, 0)
                 self.recalculate()
@@ -266,12 +268,13 @@ class FPArea(gtk.DrawingArea):
         return True
 
     def release_event(self, event):
-        print event
+        print(event)
         if event.button == 1:
-            print "Relase drag"
+            print("Relase drag")
             self.dragging_object = None
         elif event.button == 2:
             self.dragging = False
+
 
 def create_menus():
     accel_group = gtk.AccelGroup()
@@ -290,6 +293,7 @@ def create_menus():
 
     return menu_bar
 
+
 def run():
     window = gtk.Window()
     window.set_geometry_hints(min_width=600, min_height=600)
@@ -298,7 +302,7 @@ def run():
     widget.set_flags(gtk.CAN_FOCUS)
     vbox = gtk.VBox(False)
     menu = create_menus()
-    #vbox.add(menu)
+    # vbox.add(menu)
     vbox.pack_start(menu, False, True, 0)
     vbox.add(widget)
     vbox.show()
@@ -308,4 +312,3 @@ def run():
 
 if __name__ == "__main__":
     run()
-


### PR DESCRIPTION
My editor redlines me when python3-flake8 fails, so I fixed all the lint errors and made the syntax py3k compatible (only relevant for `print` statements). Probably those should be `logging.debug` or something, anyways?
